### PR TITLE
Riv 977 use tranclusion to maintain a single error list file but making it available on all the faq

### DIFF
--- a/dev-shipperhq/docs/insight/faq.md
+++ b/dev-shipperhq/docs/insight/faq.md
@@ -7,8 +7,6 @@ tags: [insight, api, faq]
 ---
 import Error from '../transclusion/error.md' // This is an included file (see below the Error component)
 
-# Shipping Insights FAQ
-
 ## Is the data for past orders available via the Insight API?
 
 No, ShipperHQ does not store shipment data until the [Shipping Insights](https://docs.shipperhq.com/shipping-insights-configuration/) Advanced Feature enabled on a ShipperHQ account. Orders placed before this feature is enabled are not available via the Insight API. Additionally, if the Shipping Insights feature is disabled, no shipment information will be stored until it is reenabled.

--- a/dev-shipperhq/docs/insight/faq.md
+++ b/dev-shipperhq/docs/insight/faq.md
@@ -5,7 +5,7 @@ title: Shipping Insights FAQ
 authors: []
 tags: [insight, api, faq]
 ---
-import Error from '../transclusion/error.md' // Assumes an integration is used to compile MDX -> JS.
+import Error from '../transclusion/error.md' // This is an included file (see below the Error component)
 
 # Shipping Insights FAQ
 

--- a/dev-shipperhq/docs/insight/faq.md
+++ b/dev-shipperhq/docs/insight/faq.md
@@ -5,6 +5,7 @@ title: Shipping Insights FAQ
 authors: []
 tags: [insight, api, faq]
 ---
+import Error from '../transclusion/error.md' // Assumes an integration is used to compile MDX -> JS.
 
 # Shipping Insights FAQ
 
@@ -25,3 +26,8 @@ Not currently. We return the [Origin](https://docs.shipperhq.com/origin-configur
 ## Is Freight Class available via Insight?
 
 Not currently. [Freight Class](https://docs.shipperhq.com/ltl-freight-carrier-configuration/#Freight_Classes) will be added in an upcoming version of the Insight API.
+
+## Error codes & messages
+[//]: # (This is an imported file - Do not modify directly this section)
+[//]: # (Look for the import statement at the top of the file to have the path of the included file)
+<Error components={props.components} />

--- a/dev-shipperhq/docs/label/faq.md
+++ b/dev-shipperhq/docs/label/faq.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 4
 ---
+import Error from '../transclusion/error.md' // This is an included file (see below the Error component)
+
 
 # FAQ
 
@@ -8,3 +10,9 @@ sidebar_position: 4
 
 The Label API is in Tbeta, and ShipperHQ is looking for early access partners.
 Please contact [support](mailto:support@shipperhq.com) to manifest your interest.
+
+## Error codes & messages
+
+[//]: # (This is an imported file - Do not modify directly this section)
+[//]: # (Look for the import statement at the top of the file to have the path of the included file)
+<Error components={props.components} />

--- a/dev-shipperhq/docs/label/faq.md
+++ b/dev-shipperhq/docs/label/faq.md
@@ -1,10 +1,8 @@
 ---
 sidebar_position: 4
+title: Label FAQ
 ---
 import Error from '../transclusion/error.md' // This is an included file (see below the Error component)
-
-
-# FAQ
 
 ## Is the Label API available?
 

--- a/dev-shipperhq/docs/rate/faq.md
+++ b/dev-shipperhq/docs/rate/faq.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 10
 ---
+import Error from '../transclusion/error.md' // Assumes an integration is used to compile MDX -> JS.
 
 # Rate FAQ
 
@@ -19,46 +20,10 @@ These errors can be categorized into several types:
 - **Account:** Indicate an issue with the ShipperHQ account configuration. For example, that the Origin being used has an invalid address. This type of error can be corrected by making the required ajustments to your ShipperHQ account.
 - **Carrier:** Indicate that ShipperHQ was unable to return results from a specific carrier. This may be intentional (e.g. error `304` indicates that the carrier is configured in ShipperHQ to explicitly not be allowed for a certain country) or unintentional (e.g. errors `305`, `306`, and `307` indicate that the request did not include information which is required by that carrier to return results). These errors may also mean that the carrier's API was unavailable when the request was attempted.
 
-### Possible Errors
 
-| Error Code | Type | Error Message |
-|------|-----|-----|
-|1|General| Request Error. There was an error processing your request.|
-|3|Auth| Invalid Credentials. The credentials you supplied are invalid.|
-|4|General| Internal server error.  We have been notified of this issue.|
-|5|General| Service Unavailable. The service is currently unavailable.  Please try again later.|
-|6|General| Access Not Allowed. This host is not permitted to access this service.|
-|7|Request| Malformed Request. The request was not formed correctly.|
-|8|Auth| Access to the webservice has been disabled for this account.|
-|300|Account| Invalid Origin Country. The origin country is invalid|
-|301|Account| Invalid Origin State. The origin state cannot be found.|
-|302|Request| Invalid Destination Country. The destination country cannot be found.|
-|303|Request| Invalid Destination State. The destination state cannot be found.|
-|304|Carrier| Disallowed Destination Country. The destination country is not allowed by this carrier.|
-|305|Carrier| Carrier requires Country and/or State one of which is missing.|
-|306|Carrier| Carrier requires City which is missing.|
-|307|Carrier| Carrier requires zipcode which is missing.|
-|308|Request| Dimensions on products are required.|
-|309|Request| Weight is required on all products for this carrier.|
-|400|Auth| Invalid Environment Scope. The environmentScope is not found for this user.|
-|401|Auth| Website not in Environment Scope. The web site does not exists in this environment scope|
-|500|Carrier| No shipping methods found for carrier. The system could not find a shipping method for the carrier.|
-|402|Account| No origins have been set up for this website.|
-|403|Account| No carriers have been setup for this origin.|
-|404|Account| No merged rates. Please review your carrier mappings.|
-|501|Carrier| Carrier Connection Error. Could not connect to carrier service for rates.  Their system is possibly down.|
-|502|Carrier| Max Weight Exceeded for Carrier. The maximum configured weight for this carrier has been exceeded. Change in carrier dashboard if wanting to increase.|
-|503|Carrier| No Pickup Locations Found. Could not find any pickup locations for this carrier.|
-|504|Account| Google API Key not present. Please set Google API Key in Global Settings on ShipperHQ Dashboard|
-|505|Carrier| Unknown Carrier Error. No rates available|
-|506|Carrier| Carrier returned error|
-|507|Carrier| No Valid Dates found for Carrier|
-|508|Carrier| No Valid Rates found for Carrier|
-|509|Carrier| Max Packages Exceeded for Carrier. The maximum number of packages for this carrier has been exceeded.|
-|510|Account| Could not find carrier you requested|
-|512|Carrier| Missing credentials for carrier.|
-|600|Account| Shipping is prevented by a user defined rule. The merchant has used Carrier Rule to prevent shipping.|
-|601|Carrier| Shipping rates removed due to priority carrier returning rates.|
-|700|Account| Missing rates for carrier groups. Unable to find rates for all of the carrier groups.|
-|800|Account| This account does not permit address validation|
-|801|Account| Address validation is not enabled.|
+
+### Error codes & messages
+
+[//]: # (This is an imported file - Do not modify directly this section)
+[//]: # (Look for the import statement at the top of the file to have the path of the included file)
+<Error components={props.components} />

--- a/dev-shipperhq/docs/rate/faq.md
+++ b/dev-shipperhq/docs/rate/faq.md
@@ -1,9 +1,8 @@
 ---
 sidebar_position: 10
+title: Rate FAQ
 ---
 import Error from '../transclusion/error.md' // This is an included file (see below the Error component)
-
-# Rate FAQ
 
 ## Does the rating API return duties (DDU/DDP) information?
 

--- a/dev-shipperhq/docs/rate/faq.md
+++ b/dev-shipperhq/docs/rate/faq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 10
 ---
-import Error from '../transclusion/error.md' // Assumes an integration is used to compile MDX -> JS.
+import Error from '../transclusion/error.md' // This is an included file (see below the Error component)
 
 # Rate FAQ
 

--- a/dev-shipperhq/docs/transclusion/error.md
+++ b/dev-shipperhq/docs/transclusion/error.md
@@ -1,4 +1,4 @@
-[//]: # (This may be the most platform independent comment)
+[//]: # (This is a file included in other files: all the FAQ of all APIs contain this file)
 
 | Error Code | Type | Error Message |
 |------|-----|-----|

--- a/dev-shipperhq/docs/transclusion/error.md
+++ b/dev-shipperhq/docs/transclusion/error.md
@@ -1,0 +1,43 @@
+[//]: # (This may be the most platform independent comment)
+
+| Error Code | Type | Error Message |
+|------|-----|-----|
+|1|General| Request Error. There was an error processing your request.|
+|3|Auth| Invalid Credentials. The credentials you supplied are invalid.|
+|4|General| Internal server error.  We have been notified of this issue.|
+|5|General| Service Unavailable. The service is currently unavailable.  Please try again later.|
+|6|General| Access Not Allowed. This host is not permitted to access this service.|
+|7|Request| Malformed Request. The request was not formed correctly.|
+|8|Auth| Access to the webservice has been disabled for this account.|
+|300|Account| Invalid Origin Country. The origin country is invalid|
+|301|Account| Invalid Origin State. The origin state cannot be found.|
+|302|Request| Invalid Destination Country. The destination country cannot be found.|
+|303|Request| Invalid Destination State. The destination state cannot be found.|
+|304|Carrier| Disallowed Destination Country. The destination country is not allowed by this carrier.|
+|305|Carrier| Carrier requires Country and/or State one of which is missing.|
+|306|Carrier| Carrier requires City which is missing.|
+|307|Carrier| Carrier requires zipcode which is missing.|
+|308|Request| Dimensions on products are required.|
+|309|Request| Weight is required on all products for this carrier.|
+|400|Auth| Invalid Environment Scope. The environmentScope is not found for this user.|
+|401|Auth| Website not in Environment Scope. The web site does not exists in this environment scope|
+|500|Carrier| No shipping methods found for carrier. The system could not find a shipping method for the carrier.|
+|402|Account| No origins have been set up for this website.|
+|403|Account| No carriers have been setup for this origin.|
+|404|Account| No merged rates. Please review your carrier mappings.|
+|501|Carrier| Carrier Connection Error. Could not connect to carrier service for rates.  Their system is possibly down.|
+|502|Carrier| Max Weight Exceeded for Carrier. The maximum configured weight for this carrier has been exceeded. Change in carrier dashboard if wanting to increase.|
+|503|Carrier| No Pickup Locations Found. Could not find any pickup locations for this carrier.|
+|504|Account| Google API Key not present. Please set Google API Key in Global Settings on ShipperHQ Dashboard|
+|505|Carrier| Unknown Carrier Error. No rates available|
+|506|Carrier| Carrier returned error|
+|507|Carrier| No Valid Dates found for Carrier|
+|508|Carrier| No Valid Rates found for Carrier|
+|509|Carrier| Max Packages Exceeded for Carrier. The maximum number of packages for this carrier has been exceeded.|
+|510|Account| Could not find carrier you requested|
+|512|Carrier| Missing credentials for carrier.|
+|600|Account| Shipping is prevented by a user defined rule. The merchant has used Carrier Rule to prevent shipping.|
+|601|Carrier| Shipping rates removed due to priority carrier returning rates.|
+|700|Account| Missing rates for carrier groups. Unable to find rates for all of the carrier groups.|
+|800|Account| This account does not permit address validation|
+|801|Account| Address validation is not enabled.|


### PR DESCRIPTION
- Removed the errors code & messages from Rate/FAQ
- created a transclusion/errors.md file with the error code
- included the transclusion/errors.md file in the three FAQ (rate, insight, label)

It is working locally with both:
- yarn start
- yarn build + yarn serve