### PR TITLE
Doc 163/partner clarification

### DIFF
--- a/dev-shipperhq/docs/labels/faq.md
+++ b/dev-shipperhq/docs/labels/faq.md
@@ -11,6 +11,12 @@ import Error from '../transclusion/error.md' // This is an included file (see be
 The ShipperHQ Labels API is currently in closed Beta. Therefore, ShipperHQ is looking for early access partners interested in participating in this program.
 Please [contact us](/contact) if interested.
 
+:::note
+
+This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+
+:::
+
 ## What are possible error codes and messages?
 [//]: # (ERROR CODES LIST)
 [//]: # (This is an imported file - Do not modify directly this section)

--- a/dev-shipperhq/docs/labels/faq.md
+++ b/dev-shipperhq/docs/labels/faq.md
@@ -13,7 +13,7 @@ Please [contact us](/contact) if interested.
 
 :::note
 
-This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+Usage of the Labels API will not be free and its use is not covered by a base ShipperHQ subscription. A cost per label will be incurred when creating labels via this API. Exact pricing will be announced in future.
 
 :::
 

--- a/dev-shipperhq/docs/labels/how-labels-work.md
+++ b/dev-shipperhq/docs/labels/how-labels-work.md
@@ -9,3 +9,9 @@ tags: [labels, api, guide, overview]
 
 The ShipperHQ Labels API is currently in closed Beta. Therefore, ShipperHQ is looking for early access partners interested in participating in this program.
 Please [contact us](/contact) if interested.
+
+:::note
+
+This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+
+:::

--- a/dev-shipperhq/docs/labels/how-labels-work.md
+++ b/dev-shipperhq/docs/labels/how-labels-work.md
@@ -12,6 +12,6 @@ Please [contact us](/contact) if interested.
 
 :::note
 
-This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+Usage of the Labels API will not be free and its use is not covered by a base ShipperHQ subscription. A cost per label will be incurred when creating labels via this API. Exact pricing will be announced in future.
 
 :::

--- a/dev-shipperhq/docs/labels/overview.md
+++ b/dev-shipperhq/docs/labels/overview.md
@@ -15,3 +15,9 @@ The Labels API enables you to produce shipping labels for shipments directly wit
 
 The ShipperHQ Labels API is currently in closed Beta. Therefore, ShipperHQ is looking for early access partners interested in participating in this program.
 Please [contact us](/contact) if interested.
+
+:::note
+
+This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+
+:::

--- a/dev-shipperhq/docs/labels/overview.md
+++ b/dev-shipperhq/docs/labels/overview.md
@@ -18,6 +18,6 @@ Please [contact us](/contact) if interested.
 
 :::note
 
-This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+Usage of the Labels API will not be free and its use is not covered by a base ShipperHQ subscription. A cost per label will be incurred when creating labels via this API. Exact pricing will be announced in future.
 
 :::

--- a/dev-shipperhq/docs/labels/quickstart.md
+++ b/dev-shipperhq/docs/labels/quickstart.md
@@ -9,3 +9,9 @@ tags: [labels, api, guide, quickstart]
 
 The ShipperHQ Labels API is currently in closed Beta. Therefore, ShipperHQ is looking for early access partners interested in participating in this program.
 Please [contact us](/contact) if interested.
+
+:::note
+
+This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+
+:::

--- a/dev-shipperhq/docs/labels/quickstart.md
+++ b/dev-shipperhq/docs/labels/quickstart.md
@@ -12,6 +12,6 @@ Please [contact us](/contact) if interested.
 
 :::note
 
-This API usage will not be free: a cost/label is incurred for each label. We are still figuring out the exact pricing but this API usage is not covered by the current monthly API call limits.
+Usage of the Labels API will not be free and its use is not covered by a base ShipperHQ subscription. A cost per label will be incurred when creating labels via this API. Exact pricing will be announced in future.
 
 :::

--- a/dev-shipperhq/docs/quickstart.md
+++ b/dev-shipperhq/docs/quickstart.md
@@ -4,7 +4,16 @@ title: Quickstart
 ---
 
 ## Introduction
-The goal of the ShipperHQ SDK is to give you the information you need to make use of the ShipperHQ APIs. Each API has its own overview, usage guide, quickstart guide, and FAQ along with detailed API reference documentation. On these you'll find detailed information related to each specific API. Below you'll find general information that applies to all of our APIs.
+The goal of the ShipperHQ SDK is to give you the information you need to use the ShipperHQ APIs. Each API has its overview, usage guide, quickstart guide, FAQ, and detailed API reference manual. On these, you'll find detailed information related to each specific API. Below you'll find general information that applies to the Developer Platform.
+
+## ShipperHQ Test Accounts
+
+In order to use ShipperHQ, you'll need to have a ShipperHQ account. Some functionality may also require that your account is on a certain ShipperHQ plan. You can create a ShipperHQ account at [ShipperHQ.com](https://shipperhq.com) which will start with a 15-day free trial.
+
+
+## Developer support
+
+To support your integration with ShipperHQ, please use our [dev support](https://dev.shipperhq.com/contact) page. Our dev support team aims to help you integrate with ShipperHQ as fast as possible with minimal hickups. Keep in mind that we are ShipperHQ expert and not expert into your own area of expertise: please share context with us including what you want to achieve and why.
 
 ## GraphQL
 Our APIs are implemented in GraphQL, an API query language. Compared to other API approaches like SOAP or standard REST, GraphQL makes it easier to request exactly the information you need from our API. This avoids the clutter and extra weight of unnecessary fields in requests and responses.
@@ -25,8 +34,3 @@ The API Playground gives you an easy way to test different ShipperHQ APIs withou
 - Click the Reload Docs icon
 - Click the Query link to view a list of available queries and the arguments and fields you can include in your request
 
-## ShipperHQ Test Accounts
-
-In order to use ShipperHQ, you'll need to have a ShipperHQ account. Some functionality may also require that your account is on a certain ShipperHQ plan. You can create a ShipperHQ account at [ShipperHQ.com](https://shipperhq.com) which will start with a 15-day free trial.
-
-For ShipperHQ partners, we can convert your account to a sandbox account if you contact your ShipperHQ partner manager directly or [contact our support team](https://dev.shipperhq.com/contact). with the login email or website URL of your ShipperHQ account. Note that partner sandbox accounts can not be converted to production accounts. If you're not currently a partner and are interested in joining, submit a request on our [Partner Program](https://shipperhq.com/partnerprogram) page.

--- a/dev-shipperhq/docs/quickstart.md
+++ b/dev-shipperhq/docs/quickstart.md
@@ -4,16 +4,16 @@ title: Quickstart
 ---
 
 ## Introduction
-The goal of the ShipperHQ SDK is to give you the information you need to use the ShipperHQ APIs. Each API has its overview, usage guide, quickstart guide, FAQ, and detailed API reference manual. On these, you'll find detailed information related to each specific API. Below you'll find general information that applies to the Developer Platform.
+The goal of the ShipperHQ SDK is to give you the information you need to use the ShipperHQ APIs. Each API has its own overview, usage guide, quickstart guide, FAQ, and API reference. On these, you'll find detailed information related to each specific API. Below you'll find general information that applies to the ShipperHQ Developer Platform as a whole.
 
 ## ShipperHQ Test Accounts
 
 In order to use ShipperHQ, you'll need to have a ShipperHQ account. Some functionality may also require that your account is on a certain ShipperHQ plan. You can create a ShipperHQ account at [ShipperHQ.com](https://shipperhq.com) which will start with a 15-day free trial.
 
 
-## Developer support
+## Developer Support
 
-To support your integration with ShipperHQ, please use our [dev support](https://dev.shipperhq.com/contact) page. Our dev support team aims to help you integrate with ShipperHQ as fast as possible with minimal hickups. Keep in mind that we are ShipperHQ expert and not expert into your own area of expertise: please share context with us including what you want to achieve and why.
+To support your integration with ShipperHQ, please use our [Dev Support](/contact) contact form. Our dev support team aims to help you integrate with ShipperHQ as fast as possible with minimal hiccups. Keep in mind that we are ShipperHQ experts, not necessarily experts into your own area of expertise: please share context with us including what you want to achieve and why.
 
 ## GraphQL
 Our APIs are implemented in GraphQL, an API query language. Compared to other API approaches like SOAP or standard REST, GraphQL makes it easier to request exactly the information you need from our API. This avoids the clutter and extra weight of unnecessary fields in requests and responses.
@@ -33,4 +33,3 @@ The API Playground gives you an easy way to test different ShipperHQ APIs withou
 - Click the Docs button
 - Click the Reload Docs icon
 - Click the Query link to view a list of available queries and the arguments and fields you can include in your request
-

--- a/dev-shipperhq/docusaurus.config.js
+++ b/dev-shipperhq/docusaurus.config.js
@@ -174,7 +174,7 @@ const config = {
           },
           {
             to: '/contact',
-            label: 'Contact Us',
+            label: 'Dev Support',
             position: 'right'
           }
           // {to: '/blog', label: 'Blog', position: 'left'},
@@ -203,7 +203,7 @@ const config = {
                 href: 'https://docs.shipperhq.com',
               },
               {
-                label: 'Contact Us',
+                label: 'Dev Support',
                 to: '/contact',
               }
         ],

--- a/dev-shipperhq/src/pages/contact.js
+++ b/dev-shipperhq/src/pages/contact.js
@@ -7,7 +7,7 @@ function Contact() {
   return (
     <Layout>
       <div className="container">
-        <h1 className="contact-title">Contact Us</h1>
+        <h1 className="contact-title">Dev support</h1>
 
         <div className="contact-form">
           <HubSpotForm portalId="20068459" formId="f34e690f-a952-4cb0-90d0-522c03304dd9" />

--- a/dev-shipperhq/src/pages/contact.js
+++ b/dev-shipperhq/src/pages/contact.js
@@ -7,7 +7,7 @@ function Contact() {
   return (
     <Layout>
       <div className="container">
-        <h1 className="contact-title">Dev support</h1>
+        <h1 className="contact-title">Dev Support</h1>
 
         <div className="contact-form">
           <HubSpotForm portalId="20068459" formId="f34e690f-a952-4cb0-90d0-522c03304dd9" />

--- a/dev-shipperhq/src/pages/index.js
+++ b/dev-shipperhq/src/pages/index.js
@@ -43,8 +43,8 @@ export default function Home() {
           <div className="questions">
 
               <div className="q-heading">
-                  <h3 className="text-2xl">Questions?</h3>
-                  <p className="mb20"> We would love to hear from you: Please <Link to="/contact">Contact Us</Link></p>
+                  <h3 className="text-2xl">Need specialized developer support?</h3>
+                  <p className="mb20"> We would love to hear from you: Please use our <Link to="/contact">Dev support</Link> contact form.</p>
                   <p>If you need help configuring ShipperHQ, please visit our <Link to="https://docs.shipperhq.com/" className="arrow-right"> ShipperHQ Help Docs</Link></p>
               </div>
           </div>

--- a/dev-shipperhq/src/pages/index.js
+++ b/dev-shipperhq/src/pages/index.js
@@ -38,14 +38,14 @@ export default function Home() {
       <HomepageHeader />
       <main>
         <HomepageFeatures />
-        
+
         <div className="container">
           <div className="questions">
 
               <div className="q-heading">
                   <h3 className="text-2xl">Need specialized developer support?</h3>
-                  <p className="mb20"> We would love to hear from you: Please use our <Link to="/contact">Dev support</Link> contact form.</p>
-                  <p>If you need help configuring ShipperHQ, please visit our <Link to="https://docs.shipperhq.com/" className="arrow-right"> ShipperHQ Help Docs</Link></p>
+                  <p className="mb20"> We would love to hear from you: Please use our <Link to="/contact">Dev Support</Link> contact form.</p>
+                  <p>If you need help configuring ShipperHQ, please visit our <Link to="https://docs.shipperhq.com/" className="arrow-right">ShipperHQ Help Docs</Link></p>
               </div>
           </div>
         </div>


### PR DESCRIPTION
- Remove the partner EAP call to action on the quickstart SDK page
- Used "Dev Support" consistently instead of "Contact us" to avoid general inquiries and better target our users
- Added a :::note on all Labels pages that this will require additional fees not covered in our API plan limits